### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that tracks stablecoin peg integrity across multiple blockchains, helping AI agents detect depegging risks before they escalate.
 
+<a href="https://glama.ai/mcp/servers/@kukapay/crypto-pegmon-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/crypto-pegmon-mcp/badge" alt="crypto-pegmon-mcp MCP server" />
+</a>
+
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue)
 ![Status](https://img.shields.io/badge/status-active-brightgreen.svg)
@@ -141,4 +145,3 @@ Generate a comprehensive stability report for a stablecoin, including historical
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-


### PR DESCRIPTION
This PR adds a badge for the [crypto-pegmon-mcp](https://glama.ai/mcp/servers/@kukapay/crypto-pegmon-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kukapay/crypto-pegmon-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/crypto-pegmon-mcp/badge" alt="crypto-pegmon-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.